### PR TITLE
fix(boot-cfg): keep additional syspath on failed partition init

### DIFF
--- a/project/ac_xm_hisense_control/board_file/boot_cfg.py
+++ b/project/ac_xm_hisense_control/board_file/boot_cfg.py
@@ -16,13 +16,15 @@ def sys_path_act():
     import sys
     import uos
 
-    bootpart = Partition(Partition.BOOT)
-    runningpart = Partition(Partition.RUNNING)
+    try:
+        bootpart = Partition(Partition.BOOT)
+        runningpart = Partition(Partition.RUNNING)
 
-    print("INFO - Partitions")
-    print(f"Boot:{bootpart}")
-    print(f" Run:{runningpart}")
-
+        print("INFO - Partitions")
+        print(f"Boot:{bootpart}")
+        print(f" Run:{runningpart}")
+    except Exception as e:
+        print(f"Init partition error: {e}")
 
     # Can be use root folder as Partion Name.
     # part_info = runningpart.info()


### PR DESCRIPTION
On my ESP32 partition-module is not working correctly (maybe kind of cloned non-original chip) but other modules work fine, except boot_cfg module. So on exception it ignores block right after partition init which prevents from normal modules importing (paths were not added to syspath, so some dynamic python-files were not able to be included):

![image](https://github.com/user-attachments/assets/0d4d8469-3887-4556-abf6-686b0770c870)

My suggestion is to move partition-init block into try/catch block, so even after exception code after partition-init block will be executed anyway. In such case all works fine except Partition-feature which I guess used for advanced OTA.
